### PR TITLE
Allow specifying custom resolver port

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Get help:
     Options:
       -w, --wordlist TEXT           Wordlist to use for brute force.
       -t, --max-tasks INTEGER       Maximum number of tasks to run asynchronosly.
+      -p, --port INTEGER            DNS resolver's custom port. Default: 53
       -r, --resolver-file FILENAME  A text file containing a list of DNS resolvers
                                     to use, one per line, comments start with #.
                                     Default: use system resolvers


### PR DESCRIPTION
May be a required option when testing internal DNS servers or solving educational tasks. Code is tested.